### PR TITLE
LoupeTarget with support for include MessageDetails in Json-format

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,43 +18,134 @@ To add this agent to your solution or build process
 --------------------------------------------------------------------------
 
 Just add the appropriate Loupe Agent for NLog NuGet package to your project
-  * [Loupe Agent for NLog 2 From NuGet](https://www.nuget.org/packages/Gibraltar.Agent.NLog2/) for NLog 2 & 3
-  * [Loupe Agent for NLog 4 From NuGet](https://www.nuget.org/packages/Gibraltar.Agent.NLog4/) for NLog 4 & later
-
+* [Loupe.Agent.NLog](https://www.nuget.org/packages/Loupe.Agent.NLog/) for NLog 4.5 and .NET Core
+* [Loupe Agent for NLog 4 From NuGet](https://www.nuget.org/packages/Gibraltar.Agent.NLog4/) for NLog 4.4 (and .NET 4.5)
+* [Loupe Agent for NLog 2 From NuGet](https://www.nuget.org/packages/Gibraltar.Agent.NLog2/) for NLog 2 & 3
+  
 This will automatically add the Loupe Agent if it hasn't been previously added.
 
-Adjust your configuration to use the GibraltarTarget
+Adjust your NLog config to include NLog target for Loupe
 ----------------------------------------------------
 
 Loupe is intended as a top-level catch-all to collect all of your logging in one managed place so you can filter
 as needed dynamically during analysis.  To do this, modify the _extensions_, _targets_, and
 _rules_ sections of your NLog configuration as follows:
 
-1. Include Gibraltar.Agent.NLog as an extension:
+**Loupe.Agent.NLog**
+Latest and recommended version with support for .NET Core and improved structured logging capabilities.
 
-For NLog 4 & Later:
-```XML
-<add assembly="Gibraltar.Agent.NLog4" />
+1. Install nuget-package:
+```
+Install-Package Loupe.Agent.NLog
 ```
 
-For NLog 2 & 3:
-```XML
-<add assembly="Gibraltar.Agent.NLog2" />
+2. Update NLog config:
+```xml
+<nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <extensions>
+        <!--Register nuget-package assembly for LoupeTarget class with target type "Loupe" -->
+        <add assembly="Loupe.Agent.NLog" />
+    </extensions>
+    <targets>
+        <!--Define a named target using the "Loupe" target type-->
+        <target name="Loupe" xsi:type="Loupe" />
+    </targets>
+    <rules>
+        <!--Send all logging to the "Loupe" named target-->
+        <logger name="*" minlevel="Trace" writeTo="Loupe" />
+    </rules>
+</nlog>
 ```
 
-2. Add the GibraltarTarget as a target:
-
-```XML
-<target name="Gibraltar" xsi:type="Gibraltar" />
+3. Start logging
 ```
-(or drop the "xsi:" prefix--just type="Gibraltar"--if not using explicit namespaces)
-
-3. Add a rule sending all logging to the GibraltarTarget:
-
-```XML
-<logger name="*" minlevel="Trace" writeTo="Gibraltar" />
+    NLog.LogManager.GetLogger("App").Info("Starting...");
 ```
-(we recommend that it be the first rule- or at least before any "final" rules - to avoid missing any).
+
+4. Additional options and Structured logging
+NLog 4.5 includes additional support for [structured logging](https://github.com/NLog/NLog/wiki/How-to-use-structured-logging):
+
+_Loupe.Agent.NLog_ has the following options to include additional message details:
+
+- _IncludeEventProperties_ - Include LogEvent properties. Default: _false_
+- _IncludeMdlc_ - Include NLog Mapped Diagnostic Logical Context (MDLC) properties. Default: _false_
+- _IncludeCallSite_ - Capture and include NLog CallSite information. Default: _true_
+- _ContextProperties_ - Capture additional properties with help from [NLog Layout-Renderers](https://nlog-project.org/config/?tab=layout-renderers).
+
+Example of using these options:
+
+```xml
+    <target name="Loupe" xsi:type="Loupe" includeEventProperties="true" includeMdlc="true">
+        <contextProperty name="threadid" layout="${threadid}" />    <!-- Additional context properties -->
+    </target>
+```
+
+**Gibraltar.Agent.NLog4**
+Support NLog 4.4 (and older) along with .NET Framework ver. 4.5
+
+1. Install nuget-package:
+```
+Install-Package Gibraltar.Agent.NLog4
+```
+
+2. Update NLog config:
+```xml
+<nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <extensions>
+        <!--Register nuget-package assembly for LoupeTarget class with target type "Loupe" -->
+        <add assembly="Gibraltar.Agent.NLog4" />
+    </extensions>
+    <targets>
+        <!--Define a named target using the "Loupe" target type-->
+        <target name="Loupe" xsi:type="Loupe" />
+    </targets>
+    <rules>
+        <!--Send all logging to the "Loupe" named target-->
+        <logger name="*" minlevel="Trace" writeTo="Loupe" />
+    </rules>
+</nlog>
+```
+
+3. Start logging
+```
+    NLog.LogManager.GetLogger("App").Info("Starting...");
+```
+
+**Gibraltar.Agent.NLog2**
+Legacyg support for NLog ver. 2 and 3
+
+1. Install nuget-package:
+```
+Install-Package Gibraltar.Agent.NLog2
+```
+
+2. Update NLog config:
+```xml
+<nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <extensions>
+        <!--Register nuget-package assembly for LoupeTarget class with target type "Loupe" -->
+        <add assembly="Gibraltar.Agent.NLog2" />
+    </extensions>
+    <targets>
+        <!--Define a named target using the "Loupe" target type-->
+        <target name="Loupe" xsi:type="Loupe" />
+    </targets>
+    <rules>
+        <!--Send all logging to the "Loupe" named target-->
+        <logger name="*" minlevel="Trace" writeTo="Loupe" />
+    </rules>
+</nlog>
+```
+
+3. Start logging
+```
+    NLog.LogManager.GetLogger("App").Info("Starting...");
+```
+
+Best Practises
+------------------
+We recommend to have the NLog logging-rule for the Loupe-target as the first rule,
+or at least before any "final" rules - to avoid missing any relevant logevents.
 
 If you find minlevel="Trace" too voluminous for normal collection, the minlevel may be set at
 "Debug" instead.  Also, see the example App.config file in the Gibraltar.Agent.NLog4 project,
@@ -64,7 +155,7 @@ Make sure to log something to Loupe early in your application to load the Loupe
 Agent and initialize its automatic monitoring features.  For example:</p>
 
 ```C#
-mainLogger.LogInfo("Entering application.");
+mainLogger.Info("Entering application.");
 ```
 
 Building the Agent

--- a/src/Agent.NLog45/Agent.NLog45.csproj
+++ b/src/Agent.NLog45/Agent.NLog45.csproj
@@ -37,7 +37,7 @@
       <Version>4.9.0.13</Version>
     </PackageReference>
     <PackageReference Include="NLog">
-      <Version>4.5.0</Version>
+      <Version>4.5.11</Version>
     </PackageReference>
   </ItemGroup>
 </Project>

--- a/src/Agent.NLog45/LoupeTarget.cs
+++ b/src/Agent.NLog45/LoupeTarget.cs
@@ -1,8 +1,10 @@
 ﻿using System;
-using System.Diagnostics;
-using System.Reflection;
+using System.Collections;
+using System.Collections.Generic;
 using Gibraltar.Agent;
+using Loupe.Configuration;
 using NLog;
+using NLog.Config;
 using NLog.Layouts;
 using NLog.Targets;
 
@@ -16,9 +18,104 @@ namespace Loupe.Agent.NLog
     {
         private const string ThisLogSystem = "NLog";
 
+        /// <summary>
+        /// Gets or sets a value indicating whether to include source info (file name and line number)
+        /// </summary>
+        public bool IncludeCallSite { get; set; }
+
+        /// <summary>
+        /// Include <see cref="LogEventInfo.Properties"/> in MessageDetails
+        /// </summary>
+        public bool IncludeEventProperties
+        {
+            get => GetMessageDetailsLayout(false)?.IncludeAllProperties ?? false;
+            set
+            {
+                var messageDetails = GetMessageDetailsLayout(value);
+                if (messageDetails != null)
+                    messageDetails.IncludeAllProperties = value;
+            }
+        }
+
+        /// <summary>
+        /// Include <see cref="MappedDiagnosticsLogicalContext"/> in MessageDetails
+        /// </summary>
+        /// <remarks>
+        /// Will include scope properties from Microsoft-Extension-Logging ILogger.BeginScope
+        /// </remarks>
+        public bool IncludeMldc
+        {
+            get => GetMessageDetailsLayout(false)?.IncludeMdlc ?? false;
+            set
+            {
+                var messageDetails = GetMessageDetailsLayout(value);
+                if (messageDetails != null)
+                    messageDetails.IncludeMdlc = value;
+            }
+        }
+
+        /// <summary>
+        /// Include additional context properties in MessageDetails
+        /// </summary>
+        [ArrayParameter(typeof(JsonAttribute), "contextproperty")]
+        public IList<JsonAttribute> ContextProperties
+        {
+            get => new ContextPropetiesProxy(this);
+            set
+            {
+                var messageDetails = GetMessageDetailsLayout(value?.Count > 0);
+                if (messageDetails != null)
+                {
+                    messageDetails.Attributes.Clear();
+                    foreach (var attribute in value)
+                        messageDetails.Attributes.Add(attribute);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Loupe already captures the class name, so the convention of using the logging class as the logger name
+        /// would mean that the default "category" may be redundant information.  If you would like to capture some other
+        /// property from the LogEventInfo as the log event's category (a dot-delimited hierarchy, similar to a namespace)
+        /// then you can add that code here.
+        /// </summary>
+        public Layout Category { get; set; }
+
+        /// <summary>
+        /// Extended message details formatted as JSON (or XML)
+        /// </summary>
+        public Layout MessageDetails { get; set; }
+
+        /// <summary>
+        /// A simple single-line message caption. (Will not be processed for formatting.)
+        /// </summary>
+        public Layout Caption { get; set; }
+
+        /// <summary>
+        /// Internal property for signalling the NLog Layout engine to capture CallSite-information
+        /// </summary>
+        public Layout EnableCallsiteLayout => IncludeCallSite ? _enableCallsiteLayout : null;
+        private Layout _enableCallsiteLayout = new SimpleLayout("${callsite}");
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LoupeTarget" /> class.
+        /// </summary>
         public LoupeTarget()
         {
-            Layout = new SimpleLayout("${callsite}"); //just to force NLog to include stack trace info.
+            Layout = "${message}";  // LogEventInfo.FormattedMessage
+            Category = "${logger}";
+            IncludeCallSite = true;
+            OptimizeBufferReuse = true; // Optimize performance of RenderLogEvent()
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LoupeTarget" /> class.
+        /// </summary>
+        public LoupeTarget(string name, AgentConfiguration agentConfiguration)
+            : this()
+        {
+            Name = name;
+            Gibraltar.Agent.Log.StartSession(agentConfiguration); // We want to be sure the session has started. This is safe to call repeatedly.
         }
 
         /// <summary>
@@ -30,35 +127,36 @@ namespace Loupe.Agent.NLog
             if (logEvent == null)
                 return;
 
-            var formattedMessage = Layout.Render(logEvent);
+            var formattedMessage = RenderLogEvent(Layout, logEvent);
+            if (string.IsNullOrEmpty(formattedMessage))
+                formattedMessage = logEvent.FormattedMessage;
+
+            var category = RenderLogEvent(Category, logEvent);
+            if (string.IsNullOrEmpty(category))
+                category = logEvent.LoggerName;
 
             var severity = GetSeverityLevel(logEvent.Level);
-            var sourceProvider = new NLogSourceProvider(logEvent);
-            var category = GetCategory(logEvent);
+            var sourceProvider = IncludeCallSite ? NLogSourceProvider.Create(logEvent) : NLogSourceProvider.NoMessageSource;
             var exception = GetException(logEvent);
+
+            var messageCaption = RenderLogEvent(Caption, logEvent);
+            if (string.IsNullOrEmpty(messageCaption))
+                messageCaption = null;
+
+            var messageDetails = RenderLogEvent(MessageDetails, logEvent);
+            if (string.IsNullOrEmpty(messageDetails))
+                messageDetails = null;
 
             // By passing null for caption it will automatically get the caption from the first line of the formatted message.
             Gibraltar.Agent.Log.Write(severity, ThisLogSystem, sourceProvider, null, exception, LogWriteMode.Queued,
-                                      null, category, null, logEvent.FormattedMessage);
+                                      messageDetails, category, messageCaption, formattedMessage);
         }
 
-        /// <summary>
-        /// A helper method to determine the "category" for a log event when sending it to Loupe.
-        /// </summary>
-        /// <param name="logEvent">The LogEventInfo for a log event.</param>
-        /// <returns>A dot-delimited hierarchy string similar to a namespace. (By default just returns the LoggerName.)</returns>
-        private static string GetCategory(LogEventInfo logEvent)
+        JsonLayout GetMessageDetailsLayout(bool allocate)
         {
-            string category = logEvent.LoggerName; // Default to just the logger name, but this is normally just the class name.
-
-            /*
-             * Loupe already captures the class name, so the convention of using the logging class as the logger name
-             * would mean that the default "category" may be redundant information.  If you would like to capture some other
-             * property from the LogEventInfo as the log event's category (a dot-delimited hierarchy, similar to a namespace)
-             * then you can add that code here.
-             */
-
-            return category;
+            if (MessageDetails == null && allocate)
+                MessageDetails = new JsonLayout() { MaxRecursionLimit = 1 };
+            return MessageDetails as JsonLayout;
         }
 
         /// <summary>
@@ -123,77 +221,135 @@ namespace Loupe.Agent.NLog
         /// </summary>
         private class NLogSourceProvider : IMessageSourceProvider
         {
-            /// <summary>
-            /// Construct an NLogSourceProvider for a given log event.
-            /// </summary>
-            /// <param name="logEvent">The LogEventInfo of the log event.</param>
-            public NLogSourceProvider(LogEventInfo logEvent)
-            {
-                MethodName = null;
-                ClassName = null;
-                FileName = null;
-                LineNumber = 0;
+            public static readonly IMessageSourceProvider NoMessageSource = new NLogSourceProvider();
 
+            public static IMessageSourceProvider Create(LogEventInfo logEvent)
+            {
                 try
                 {
-                    StackFrame frame = logEvent.UserStackFrame;
-                    if (frame != null)
-                    {
-                        MethodBase method = frame.GetMethod();
-                        if (method != null)
-                        {
-                            MethodName = method.Name;
-                            ClassName = method.ReflectedType.FullName;
+                    var methodName = logEvent.CallerMemberName;
+                    if (string.IsNullOrEmpty(methodName))
+                        methodName = null;
+                    var className = logEvent.CallerClassName;
+                    if (string.IsNullOrEmpty(className))
+                        className = null;
+                    var fileName = logEvent.CallerFilePath;
+                    if (string.IsNullOrEmpty(fileName))
+                        fileName = null;
 
-                            try
-                            {
-                                // Now see if we also have file information.
-                                FileName = frame.GetFileName();
-                                if (string.IsNullOrEmpty(FileName) == false)
-                                {
-                                    LineNumber = frame.GetFileLineNumber();
-                                }
-                                else
-                                {
-                                    LineNumber = 0; // Not meaningful if there's no file name!
-                                }
-                            }
-                            catch
-                            {
-                                FileName = null;
-                                LineNumber = 0;
-                            }
-                        }
+                    if (methodName != null || className != null || fileName != null)
+                    {
+                        if (string.IsNullOrEmpty(className))
+                            className = logEvent.LoggerName;
+                        var lineNumber = logEvent.CallerLineNumber;
+                        return new NLogSourceProvider() { ClassName = className, MethodName = methodName, FileName = fileName, LineNumber = lineNumber };
                     }
                 }
                 catch
                 {
-                    MethodName = null;
-                    ClassName = null;
-                    FileName = null;
-                    LineNumber = 0;
+                    // No message source available
                 }
+
+                return NoMessageSource;
             }
 
             /// <summary>
             /// Should return the simple name of the method which issued the log message.
             /// </summary>
-            public string MethodName { get; }
+            public string MethodName { get; private set; }
 
             /// <summary>
             /// Should return the full name of the class (with namespace) whose method issued the log message.
             /// </summary>
-            public string ClassName { get; }
+            public string ClassName { get; private set; }
 
             /// <summary>
             /// Should return the name of the file containing the method which issued the log message.
             /// </summary>
-            public string FileName { get; }
+            public string FileName { get; private set; }
 
             /// <summary>
             /// Should return the line within the file at which the log message was issued.
             /// </summary>
-            public int LineNumber { get; }
+            public int LineNumber { get; private set; }
+        }
+
+        /// <summary>
+        /// IList-Proxy for ContextProperties to skip allocation and rendering using JsonLayout unless requested
+        /// </summary>
+        private class ContextPropetiesProxy : IList<JsonAttribute>, IList
+        {
+            private readonly LoupeTarget _loupeTarget;
+            IList<JsonAttribute> _contextProperties;
+
+            public ContextPropetiesProxy(LoupeTarget loupeTarget)
+            {
+                _loupeTarget = loupeTarget;
+                _contextProperties = GetContextProperties(false);
+            }
+
+            private IList<JsonAttribute> GetContextProperties(bool allocate = true)
+            {
+                return _contextProperties = _loupeTarget.GetMessageDetailsLayout(allocate)?.Attributes ?? Array.Empty<JsonAttribute>();
+            }
+
+            public JsonAttribute this[int index] { get => _contextProperties[index]; set => _contextProperties[index] = value; }
+            object IList.this[int index] { get => _contextProperties[index]; set => _contextProperties[index] = (JsonAttribute)value; }
+
+            public int Count => _contextProperties.Count;
+
+            public bool IsReadOnly => _contextProperties.IsReadOnly;
+
+            bool IList.IsFixedSize => false;
+
+            object ICollection.SyncRoot => this;
+
+            bool ICollection.IsSynchronized => true;
+
+            public void Add(JsonAttribute item)
+            {
+                GetContextProperties()?.Add(item);
+            }
+
+            public void Insert(int index, JsonAttribute item)
+            {
+                GetContextProperties()?.Insert(index, item);
+            }
+
+            public bool Remove(JsonAttribute item)
+            {
+                return GetContextProperties()?.Remove(item) ?? false;
+            }
+
+            public void RemoveAt(int index)
+            {
+                GetContextProperties()?.RemoveAt(index);
+            }
+
+            public void Clear()
+            {
+                if (_contextProperties?.Count > 0)
+                    _contextProperties.Clear();
+            }
+
+            public IEnumerator<JsonAttribute> GetEnumerator() => _contextProperties.GetEnumerator();
+            IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)_contextProperties).GetEnumerator();
+
+            int IList.Add(object value)
+            {
+                Add((JsonAttribute)value);
+                return Count - 1;
+            }
+
+            public bool Contains(JsonAttribute item) => _contextProperties.Contains(item);
+            public void CopyTo(JsonAttribute[] array, int arrayIndex) => _contextProperties.CopyTo(array, arrayIndex);
+            public int IndexOf(JsonAttribute item) => _contextProperties.IndexOf(item);
+
+            bool IList.Contains(object value) => _contextProperties.Contains((JsonAttribute)value);
+            int IList.IndexOf(object value) => _contextProperties.IndexOf((JsonAttribute)value);
+            void IList.Insert(int index, object value) => _contextProperties.Insert(index, (JsonAttribute)value);
+            void IList.Remove(object value) => _contextProperties.Remove((JsonAttribute)value);
+            void ICollection.CopyTo(Array array, int index) => _contextProperties.CopyTo((JsonAttribute[])array, index);
         }
     }
 }

--- a/src/NLog45Test/NLog45Test.csproj
+++ b/src/NLog45Test/NLog45Test.csproj
@@ -92,7 +92,7 @@
       <DependentUpon>Resources.resx</DependentUpon>
       <DesignTime>True</DesignTime>
     </Compile>
-    <None Include="App.config" />
+	<None Include="App.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
@@ -132,7 +132,7 @@
       <Version>4.9.0.13</Version>
     </PackageReference>
     <PackageReference Include="NLog">
-      <Version>4.5.0</Version>
+      <Version>4.5.11</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/NLog45Test/TestForm.cs
+++ b/src/NLog45Test/TestForm.cs
@@ -32,7 +32,7 @@ namespace NLogTest
             }
             catch (Exception ex)
             {
-                m_Log.ErrorException("Oh Snap!  We just had an exception!", ex);
+                m_Log.Error(ex, "Oh Snap!  We just had an exception!");
             }
         }
 


### PR DESCRIPTION
Added `IncludeEventProperties` + `IncludeMldc` + `ContextProperties`.

Possible to do this:

```xml
<target name="Loupe" xsi:type="Loupe" includeEventProperties="true">
    <contextProperty name="threadid" layout="${threadid}" />
</target>
```

This will match `Loupe.Serilog` way of resolving details by including LogEvent-Properties.
