### PR TITLE
LoupeTarget with support for include MessageDetails in Json-format

### DIFF
--- a/src/Agent.NLog45/Agent.NLog45.csproj
+++ b/src/Agent.NLog45/Agent.NLog45.csproj
@@ -37,7 +37,7 @@
       <Version>4.9.0.13</Version>
     </PackageReference>
     <PackageReference Include="NLog">
-      <Version>4.5.0</Version>
+      <Version>4.5.11</Version>
     </PackageReference>
   </ItemGroup>
 </Project>

--- a/src/Agent.NLog45/LoupeTarget.cs
+++ b/src/Agent.NLog45/LoupeTarget.cs
@@ -1,8 +1,10 @@
 ﻿using System;
-using System.Diagnostics;
-using System.Reflection;
+using System.Collections;
+using System.Collections.Generic;
 using Gibraltar.Agent;
+using Loupe.Configuration;
 using NLog;
+using NLog.Config;
 using NLog.Layouts;
 using NLog.Targets;
 
@@ -16,9 +18,104 @@ namespace Loupe.Agent.NLog
     {
         private const string ThisLogSystem = "NLog";
 
+        /// <summary>
+        /// Gets or sets a value indicating whether to include source info (file name and line number)
+        /// </summary>
+        public bool IncludeCallSite { get; set; }
+
+        /// <summary>
+        /// Include <see cref="LogEventInfo.Properties"/> in MessageDetails
+        /// </summary>
+        public bool IncludeEventProperties
+        {
+            get => GetMessageDetailsLayout(false)?.IncludeAllProperties ?? false;
+            set
+            {
+                var messageDetails = GetMessageDetailsLayout(value);
+                if (messageDetails != null)
+                    messageDetails.IncludeAllProperties = value;
+            }
+        }
+
+        /// <summary>
+        /// Include <see cref="MappedDiagnosticsLogicalContext"/> in MessageDetails
+        /// </summary>
+        /// <remarks>
+        /// Will include scope properties from Microsoft-Extension-Logging ILogger.BeginScope
+        /// </remarks>
+        public bool IncludeMldc
+        {
+            get => GetMessageDetailsLayout(false)?.IncludeMdlc ?? false;
+            set
+            {
+                var messageDetails = GetMessageDetailsLayout(value);
+                if (messageDetails != null)
+                    messageDetails.IncludeMdlc = value;
+            }
+        }
+
+        /// <summary>
+        /// Include additional context properties in MessageDetails
+        /// </summary>
+        [ArrayParameter(typeof(JsonAttribute), "contextproperty")]
+        public IList<JsonAttribute> ContextProperties
+        {
+            get => new ContextPropetiesProxy(this);
+            set
+            {
+                var messageDetails = GetMessageDetailsLayout(value?.Count > 0);
+                if (messageDetails != null)
+                {
+                    messageDetails.Attributes.Clear();
+                    foreach (var attribute in value)
+                        messageDetails.Attributes.Add(attribute);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Loupe already captures the class name, so the convention of using the logging class as the logger name
+        /// would mean that the default "category" may be redundant information.  If you would like to capture some other
+        /// property from the LogEventInfo as the log event's category (a dot-delimited hierarchy, similar to a namespace)
+        /// then you can add that code here.
+        /// </summary>
+        public Layout Category { get; set; }
+
+        /// <summary>
+        /// Extended message details formatted as JSON (or XML)
+        /// </summary>
+        public Layout MessageDetails { get; set; }
+
+        /// <summary>
+        /// A simple single-line message caption. (Will not be processed for formatting.)
+        /// </summary>
+        public Layout Caption { get; set; }
+
+        /// <summary>
+        /// Internal property for signalling the NLog Layout engine to capture CallSite-information
+        /// </summary>
+        public Layout EnableCallsiteLayout => IncludeCallSite ? _enableCallsiteLayout : null;
+        private Layout _enableCallsiteLayout = new SimpleLayout("${callsite}");
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LoupeTarget" /> class.
+        /// </summary>
         public LoupeTarget()
         {
-            Layout = new SimpleLayout("${callsite}"); //just to force NLog to include stack trace info.
+            Layout = "${message}";  // LogEventInfo.FormattedMessage
+            Category = "${logger}";
+            IncludeCallSite = true;
+            OptimizeBufferReuse = true; // Optimize performance of RenderLogEvent()
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LoupeTarget" /> class.
+        /// </summary>
+        public LoupeTarget(string name, AgentConfiguration agentConfiguration)
+            : this()
+        {
+            Name = name;
+            Gibraltar.Agent.Log.StartSession(agentConfiguration); // We want to be sure the session has started. This is safe to call repeatedly.
         }
 
         /// <summary>
@@ -30,35 +127,36 @@ namespace Loupe.Agent.NLog
             if (logEvent == null)
                 return;
 
-            var formattedMessage = Layout.Render(logEvent);
+            var formattedMessage = RenderLogEvent(Layout, logEvent);
+            if (string.IsNullOrEmpty(formattedMessage))
+                formattedMessage = logEvent.FormattedMessage;
+
+            var category = RenderLogEvent(Category, logEvent);
+            if (string.IsNullOrEmpty(category))
+                category = logEvent.LoggerName;
 
             var severity = GetSeverityLevel(logEvent.Level);
-            var sourceProvider = new NLogSourceProvider(logEvent);
-            var category = GetCategory(logEvent);
+            var sourceProvider = IncludeCallSite ? NLogSourceProvider.Create(logEvent) : NLogSourceProvider.NoMessageSource;
             var exception = GetException(logEvent);
+
+            var messageCaption = RenderLogEvent(Caption, logEvent);
+            if (string.IsNullOrEmpty(messageCaption))
+                messageCaption = null;
+
+            var messageDetails = RenderLogEvent(MessageDetails, logEvent);
+            if (string.IsNullOrEmpty(messageDetails))
+                messageDetails = null;
 
             // By passing null for caption it will automatically get the caption from the first line of the formatted message.
             Gibraltar.Agent.Log.Write(severity, ThisLogSystem, sourceProvider, null, exception, LogWriteMode.Queued,
-                                      null, category, null, logEvent.FormattedMessage);
+                                      messageDetails, category, messageCaption, formattedMessage);
         }
 
-        /// <summary>
-        /// A helper method to determine the "category" for a log event when sending it to Loupe.
-        /// </summary>
-        /// <param name="logEvent">The LogEventInfo for a log event.</param>
-        /// <returns>A dot-delimited hierarchy string similar to a namespace. (By default just returns the LoggerName.)</returns>
-        private static string GetCategory(LogEventInfo logEvent)
+        JsonLayout GetMessageDetailsLayout(bool allocate)
         {
-            string category = logEvent.LoggerName; // Default to just the logger name, but this is normally just the class name.
-
-            /*
-             * Loupe already captures the class name, so the convention of using the logging class as the logger name
-             * would mean that the default "category" may be redundant information.  If you would like to capture some other
-             * property from the LogEventInfo as the log event's category (a dot-delimited hierarchy, similar to a namespace)
-             * then you can add that code here.
-             */
-
-            return category;
+            if (MessageDetails == null && allocate)
+                MessageDetails = new JsonLayout() { MaxRecursionLimit = 1 };
+            return MessageDetails as JsonLayout;
         }
 
         /// <summary>
@@ -123,77 +221,135 @@ namespace Loupe.Agent.NLog
         /// </summary>
         private class NLogSourceProvider : IMessageSourceProvider
         {
-            /// <summary>
-            /// Construct an NLogSourceProvider for a given log event.
-            /// </summary>
-            /// <param name="logEvent">The LogEventInfo of the log event.</param>
-            public NLogSourceProvider(LogEventInfo logEvent)
-            {
-                MethodName = null;
-                ClassName = null;
-                FileName = null;
-                LineNumber = 0;
+            public static readonly IMessageSourceProvider NoMessageSource = new NLogSourceProvider();
 
+            public static IMessageSourceProvider Create(LogEventInfo logEvent)
+            {
                 try
                 {
-                    StackFrame frame = logEvent.UserStackFrame;
-                    if (frame != null)
-                    {
-                        MethodBase method = frame.GetMethod();
-                        if (method != null)
-                        {
-                            MethodName = method.Name;
-                            ClassName = method.ReflectedType.FullName;
+                    var methodName = logEvent.CallerMemberName;
+                    if (string.IsNullOrEmpty(methodName))
+                        methodName = null;
+                    var className = logEvent.CallerClassName;
+                    if (string.IsNullOrEmpty(className))
+                        className = null;
+                    var fileName = logEvent.CallerFilePath;
+                    if (string.IsNullOrEmpty(fileName))
+                        fileName = null;
 
-                            try
-                            {
-                                // Now see if we also have file information.
-                                FileName = frame.GetFileName();
-                                if (string.IsNullOrEmpty(FileName) == false)
-                                {
-                                    LineNumber = frame.GetFileLineNumber();
-                                }
-                                else
-                                {
-                                    LineNumber = 0; // Not meaningful if there's no file name!
-                                }
-                            }
-                            catch
-                            {
-                                FileName = null;
-                                LineNumber = 0;
-                            }
-                        }
+                    if (methodName != null || className != null || fileName != null)
+                    {
+                        if (string.IsNullOrEmpty(className))
+                            className = logEvent.LoggerName;
+                        var lineNumber = logEvent.CallerLineNumber;
+                        return new NLogSourceProvider() { ClassName = className, MethodName = methodName, FileName = fileName, LineNumber = lineNumber };
                     }
                 }
                 catch
                 {
-                    MethodName = null;
-                    ClassName = null;
-                    FileName = null;
-                    LineNumber = 0;
+                    // No message source available
                 }
+
+                return NoMessageSource;
             }
 
             /// <summary>
             /// Should return the simple name of the method which issued the log message.
             /// </summary>
-            public string MethodName { get; }
+            public string MethodName { get; private set; }
 
             /// <summary>
             /// Should return the full name of the class (with namespace) whose method issued the log message.
             /// </summary>
-            public string ClassName { get; }
+            public string ClassName { get; private set; }
 
             /// <summary>
             /// Should return the name of the file containing the method which issued the log message.
             /// </summary>
-            public string FileName { get; }
+            public string FileName { get; private set; }
 
             /// <summary>
             /// Should return the line within the file at which the log message was issued.
             /// </summary>
-            public int LineNumber { get; }
+            public int LineNumber { get; private set; }
+        }
+
+        /// <summary>
+        /// IList-Proxy for ContextProperties to skip allocation and rendering using JsonLayout unless requested
+        /// </summary>
+        private class ContextPropetiesProxy : IList<JsonAttribute>, IList
+        {
+            private readonly LoupeTarget _loupeTarget;
+            IList<JsonAttribute> _contextProperties;
+
+            public ContextPropetiesProxy(LoupeTarget loupeTarget)
+            {
+                _loupeTarget = loupeTarget;
+                _contextProperties = GetContextProperties(false);
+            }
+
+            private IList<JsonAttribute> GetContextProperties(bool allocate = true)
+            {
+                return _contextProperties = _loupeTarget.GetMessageDetailsLayout(allocate)?.Attributes ?? Array.Empty<JsonAttribute>();
+            }
+
+            public JsonAttribute this[int index] { get => _contextProperties[index]; set => _contextProperties[index] = value; }
+            object IList.this[int index] { get => _contextProperties[index]; set => _contextProperties[index] = (JsonAttribute)value; }
+
+            public int Count => _contextProperties.Count;
+
+            public bool IsReadOnly => _contextProperties.IsReadOnly;
+
+            bool IList.IsFixedSize => false;
+
+            object ICollection.SyncRoot => this;
+
+            bool ICollection.IsSynchronized => true;
+
+            public void Add(JsonAttribute item)
+            {
+                GetContextProperties()?.Add(item);
+            }
+
+            public void Insert(int index, JsonAttribute item)
+            {
+                GetContextProperties()?.Insert(index, item);
+            }
+
+            public bool Remove(JsonAttribute item)
+            {
+                return GetContextProperties()?.Remove(item) ?? false;
+            }
+
+            public void RemoveAt(int index)
+            {
+                GetContextProperties()?.RemoveAt(index);
+            }
+
+            public void Clear()
+            {
+                if (_contextProperties?.Count > 0)
+                    _contextProperties.Clear();
+            }
+
+            public IEnumerator<JsonAttribute> GetEnumerator() => _contextProperties.GetEnumerator();
+            IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)_contextProperties).GetEnumerator();
+
+            int IList.Add(object value)
+            {
+                Add((JsonAttribute)value);
+                return Count - 1;
+            }
+
+            public bool Contains(JsonAttribute item) => _contextProperties.Contains(item);
+            public void CopyTo(JsonAttribute[] array, int arrayIndex) => _contextProperties.CopyTo(array, arrayIndex);
+            public int IndexOf(JsonAttribute item) => _contextProperties.IndexOf(item);
+
+            bool IList.Contains(object value) => _contextProperties.Contains((JsonAttribute)value);
+            int IList.IndexOf(object value) => _contextProperties.IndexOf((JsonAttribute)value);
+            void IList.Insert(int index, object value) => _contextProperties.Insert(index, (JsonAttribute)value);
+            void IList.Remove(object value) => _contextProperties.Remove((JsonAttribute)value);
+            void ICollection.CopyTo(Array array, int index) => _contextProperties.CopyTo((JsonAttribute[])array, index);
         }
     }
 }

--- a/src/Agent.NLog45/LoupeTarget.cs
+++ b/src/Agent.NLog45/LoupeTarget.cs
@@ -60,7 +60,7 @@ namespace Loupe.Agent.NLog
         [ArrayParameter(typeof(JsonAttribute), "contextproperty")]
         public IList<JsonAttribute> ContextProperties
         {
-            get => new ContextPropetiesProxy(this);
+            get => new ContextPropertiesProxy(this);
             set
             {
                 var messageDetails = GetMessageDetailsLayout(value?.Count > 0);
@@ -277,12 +277,12 @@ namespace Loupe.Agent.NLog
         /// <summary>
         /// IList-Proxy for ContextProperties to skip allocation and rendering using JsonLayout unless requested
         /// </summary>
-        private class ContextPropetiesProxy : IList<JsonAttribute>, IList
+        private class ContextPropertiesProxy : IList<JsonAttribute>, IList
         {
             private readonly LoupeTarget _loupeTarget;
             IList<JsonAttribute> _contextProperties;
 
-            public ContextPropetiesProxy(LoupeTarget loupeTarget)
+            public ContextPropertiesProxy(LoupeTarget loupeTarget)
             {
                 _loupeTarget = loupeTarget;
                 _contextProperties = GetContextProperties(false);

--- a/src/NLog45Test/NLog45Test.csproj
+++ b/src/NLog45Test/NLog45Test.csproj
@@ -92,7 +92,7 @@
       <DependentUpon>Resources.resx</DependentUpon>
       <DesignTime>True</DesignTime>
     </Compile>
-    <None Include="App.config" />
+	<None Include="App.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
@@ -132,7 +132,7 @@
       <Version>4.9.0.13</Version>
     </PackageReference>
     <PackageReference Include="NLog">
-      <Version>4.5.0</Version>
+      <Version>4.5.11</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/NLog45Test/TestForm.cs
+++ b/src/NLog45Test/TestForm.cs
@@ -32,7 +32,7 @@ namespace NLogTest
             }
             catch (Exception ex)
             {
-                m_Log.ErrorException("Oh Snap!  We just had an exception!", ex);
+                m_Log.Error(ex, "Oh Snap!  We just had an exception!");
             }
         }
 


### PR DESCRIPTION
Added `IncludeEventProperties` + `IncludeMldc` + `ContextProperties`.

Possible to do this:

```xml
<target name="Loupe" xsi:type="Loupe" includeEventProperties="true">
    <contextProperty name="threadid" layout="${threadid}" />
</target>
```

This will match `Loupe.Serilog` way of resolving details by including LogEvent-Properties.
