### PR TITLE
Updated dependencies Loupe.Agent.Core + NLog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,5 +107,5 @@ Generated_Code #added for RIA/Silverlight projects
 _UpgradeReport_Files/
 Backup*/
 UpgradeLog*.XML
-/.vs
+.vs
 *.snk

--- a/src/Agent.NLog45/Agent.NLog45.csproj
+++ b/src/Agent.NLog45/Agent.NLog45.csproj
@@ -6,13 +6,13 @@
     <AssemblyName>Loupe.Agent.NLog</AssemblyName>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Loupe.Agent.NLog</PackageId>
-	  <Version>5.0.0.0</Version>
-	  <FileVersion>5.0.0.0</FileVersion>
+	  <Version>5.0.0.26</Version>
+	  <FileVersion>5.0.0.26</FileVersion>
 	  <AssemblyVersion>5.0.0.0</AssemblyVersion>
     <Company>Gibraltar Software, Inc.</Company>
     <Authors>Gibraltar Software, Inc.</Authors>
     <Product>Loupe</Product>
-    <Copyright>Copyright © 2008-2023 Gibraltar Software, Inc.</Copyright>
+    <Copyright>Copyright © 2008-2024 Gibraltar Software, Inc.</Copyright>
     <PackageProjectUrl>https://onloupe.com</PackageProjectUrl>
     <PackageIcon>loupe-192x192.png</PackageIcon>
     <RepositoryUrl>https://github.com/gibraltarsoftware/gibraltar.agent.nlog2</RepositoryUrl>
@@ -41,14 +41,14 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Loupe.Agent.Core">
-      <Version>5.0.0.1</Version>
+      <Version>5.0.0.26</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="NLog">
-      <Version>4.5.11</Version>
+      <Version>4.7.15</Version>
     </PackageReference>
   </ItemGroup>
 </Project>

--- a/src/Agent.NLog45/LoupeTarget.cs
+++ b/src/Agent.NLog45/LoupeTarget.cs
@@ -155,7 +155,7 @@ namespace Loupe.Agent.NLog
         JsonLayout GetMessageDetailsLayout(bool allocate)
         {
             if (MessageDetails == null && allocate)
-                MessageDetails = new JsonLayout() { MaxRecursionLimit = 1 };
+                MessageDetails = new JsonLayout() { MaxRecursionLimit = 1, RenderEmptyObject = false, EscapeForwardSlash = false };
             return MessageDetails as JsonLayout;
         }
 

--- a/src/NLog45Test/NLog45Test.csproj
+++ b/src/NLog45Test/NLog45Test.csproj
@@ -129,10 +129,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Loupe.Agent.Core">
-      <Version>5.0.0.1</Version>
+      <Version>5.0.0.26</Version>
     </PackageReference>
     <PackageReference Include="NLog">
-      <Version>4.5.11</Version>
+      <Version>4.7.15</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
- Loupe.Agent.Core ver. 5.0.0.26
- NLog ver. 4.7.15
- Better JsonLayout defaults when using `IncludeEventProperties = true` (Skip MessageDetails output when no properties)